### PR TITLE
feat: ログ出力を改善しタイムスタンプをUnix秒に統一

### DIFF
--- a/logic/common.go
+++ b/logic/common.go
@@ -3,6 +3,7 @@ package logic
 import (
 	"errors"
 	"log/slog"
+	"time"
 
 	"github.com/aiwolfdial/aiwolf-nlp-server/model"
 	"github.com/aiwolfdial/aiwolf-nlp-server/util"
@@ -176,6 +177,7 @@ func (g *Game) getRealtimeBroadcastPacket() model.BroadcastPacket {
 		ToIdx:     nil,
 		BubbleIdx: nil,
 	}
+	packet.Timestamp = time.Now().Unix()
 	for _, a := range g.agents {
 		agent := struct {
 			Idx     int     `json:"idx"`

--- a/logic/communication_freeform.go
+++ b/logic/communication_freeform.go
@@ -54,6 +54,9 @@ func (s *CommunicationSession) runFreeform() {
 					s.appendTalk(talk)
 					s.sendTalk(talk)
 					s.logTalk(talk)
+					if s.game.jsonLogger != nil {
+						s.game.jsonLogger.TrackTalk(s.game.id, *submission.Agent, s.request, talk)
+					}
 				}
 				if s.allAgentsDone() {
 					slog.Info("全エージェントの発言が終了したため、早期終了します", "id", s.game.id)
@@ -86,6 +89,9 @@ func (s *CommunicationSession) sendStart() {
 		request = model.R_WHISPER_PHASE_START
 	}
 	s.send(request, nil)
+	if s.game.jsonLogger != nil {
+		s.game.jsonLogger.TrackPhase(s.game.id, request)
+	}
 }
 
 func (s *CommunicationSession) sendEnd() {
@@ -94,6 +100,9 @@ func (s *CommunicationSession) sendEnd() {
 		request = model.R_WHISPER_PHASE_END
 	}
 	s.send(request, nil)
+	if s.game.jsonLogger != nil {
+		s.game.jsonLogger.TrackPhase(s.game.id, request)
+	}
 }
 
 func (s *CommunicationSession) sendTalk(talk model.Talk) {

--- a/logic/communication_session.go
+++ b/logic/communication_session.go
@@ -258,11 +258,7 @@ func (s *CommunicationSession) logTalk(talk model.Talk) {
 		if s.request != model.R_TALK {
 			kind = "whisper"
 		}
-		if s.talkSetting.Duration != nil {
-			s.game.gameLogger.AppendLog(s.game.id, fmt.Sprintf("%d,%s,%d,%d,%d,%s,%d", s.game.currentDay, kind, talk.Idx, talk.Turn, talk.Agent.Idx, talk.Text, talk.Time.UnixMilli()))
-		} else {
-			s.game.gameLogger.AppendLog(s.game.id, fmt.Sprintf("%d,%s,%d,%d,%d,%s", s.game.currentDay, kind, talk.Idx, talk.Turn, talk.Agent.Idx, talk.Text))
-		}
+		s.game.gameLogger.AppendLog(s.game.id, fmt.Sprintf("%d,%s,%d,%d,%d,%s,%d", s.game.currentDay, kind, talk.Idx, talk.Turn, talk.Agent.Idx, talk.Text, talk.Time.Unix()))
 	}
 	if s.game.realtimeBroadcaster != nil {
 		packet := s.game.getRealtimeBroadcastPacket()

--- a/model/broadcast_packet.go
+++ b/model/broadcast_packet.go
@@ -19,4 +19,5 @@ type BroadcastPacket struct {
 	FromIdx   *int    `json:"from_idx,omitempty"`
 	ToIdx     *int    `json:"to_idx,omitempty"`
 	BubbleIdx *int    `json:"bubble_idx,omitempty"`
+	Timestamp int64   `json:"timestamp"`
 }

--- a/service/json_logger.go
+++ b/service/json_logger.go
@@ -83,7 +83,7 @@ func (j *JSONLogger) TrackEndGame(id string, winSide model.Team) {
 func (j *JSONLogger) TrackStartRequest(id string, agent model.Agent, packet model.Packet) {
 	if dataInterface, exists := j.data.Load(id); exists {
 		data := dataInterface.(*JSONLog)
-		data.timestampMap.Store(agent.OriginalName, time.Now().UnixNano())
+		data.timestampMap.Store(agent.OriginalName, time.Now().Unix())
 		data.requestMap.Store(agent.OriginalName, packet)
 	}
 }
@@ -91,15 +91,15 @@ func (j *JSONLogger) TrackStartRequest(id string, agent model.Agent, packet mode
 func (j *JSONLogger) TrackEndRequest(id string, agent model.Agent, response string, err error) {
 	if dataInterface, exists := j.data.Load(id); exists {
 		data := dataInterface.(*JSONLog)
-		timestamp := time.Now().UnixNano()
+		timestamp := time.Now().Unix()
 
 		entry := map[string]any{
 			"agent":              agent.String(),
-			"response_timestamp": timestamp / 1e6,
+			"response_timestamp": timestamp,
 		}
 
 		if requestTimestampInterface, exists := data.timestampMap.LoadAndDelete(agent.OriginalName); exists {
-			entry["request_timestamp"] = requestTimestampInterface.(int64) / 1e6
+			entry["request_timestamp"] = requestTimestampInterface.(int64)
 		}
 
 		if requestInterface, exists := data.requestMap.LoadAndDelete(agent.OriginalName); exists {

--- a/service/json_logger.go
+++ b/service/json_logger.go
@@ -124,6 +124,53 @@ func (j *JSONLogger) TrackEndRequest(id string, agent model.Agent, response stri
 	}
 }
 
+func (j *JSONLogger) TrackTalk(id string, agent model.Agent, request model.Request, talk model.Talk) {
+	if dataInterface, exists := j.data.Load(id); exists {
+		data := dataInterface.(*JSONLog)
+
+		entry := map[string]any{
+			"agent":              agent.String(),
+			"response":           talk.Text,
+			"request_timestamp":  talk.Time.Unix(),
+			"response_timestamp": talk.Time.Unix(),
+		}
+
+		if jsonData, marshalErr := json.Marshal(request); marshalErr == nil {
+			entry["request"] = string(jsonData)
+		}
+
+		data.mu.Lock()
+		data.entries = append(data.entries, entry)
+		data.mu.Unlock()
+
+		j.saveGameData(id)
+	}
+}
+
+func (j *JSONLogger) TrackPhase(id string, request model.Request) {
+	if dataInterface, exists := j.data.Load(id); exists {
+		data := dataInterface.(*JSONLog)
+
+		now := time.Now().Unix()
+
+		entry := map[string]any{
+			"agent":              "",
+			"request_timestamp":  now,
+			"response_timestamp": now,
+		}
+
+		if jsonData, marshalErr := json.Marshal(request); marshalErr == nil {
+			entry["request"] = string(jsonData)
+		}
+
+		data.mu.Lock()
+		data.entries = append(data.entries, entry)
+		data.mu.Unlock()
+
+		j.saveGameData(id)
+	}
+}
+
 func (j *JSONLogger) saveGameData(id string) {
 	if dataInterface, exists := j.data.Load(id); exists {
 		data := dataInterface.(*JSONLog)


### PR DESCRIPTION
## Summary
- game log (.log): 常にタイムスタンプ(Unix秒)を付与するよう変更（freeformモード限定を解除）
- JSON log (.json): freeformモードのトーク記録(`TrackTalk`/`TrackPhase`)を追加
- JSONL (.jsonl): `BroadcastPacket`に`timestamp`フィールドを追加（Unix秒）

## Test plan
- [ ] freeformモードでゲームを実行し、.logファイルの全talk/whisper行に10桁タイムスタンプが付与されていることを確認
- [ ] .jsonファイルにTALK/WHISPER/TALK_PHASE_START/TALK_PHASE_ENDエントリが記録されていることを確認
- [ ] .jsonlファイルの各パケットにtimestampフィールドがあることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)